### PR TITLE
Add Mouse Mode to final scene

### DIFF
--- a/Levels/Level1.tscn
+++ b/Levels/Level1.tscn
@@ -20,6 +20,6 @@ data = {
 }
 
 [node name="Objective" parent="." instance=ExtResource("2_64pqg")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 44.4746, 4.65405, 41.7542)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.44757, 4.65405, 10.5118)
 
 [connection signal="body_entered" from="Objective" to="." method="_on_objective_body_entered"]

--- a/Scripts/FinalMenu.gd
+++ b/Scripts/FinalMenu.gd
@@ -9,7 +9,7 @@ func initialize(total_play_time : float) -> void:
 	var seconds : String = str(int(fmod(total_play_time, 60.0)))
 	var time_text = "Total time: %s m %s s" %[minutes, seconds]
 	time.text = time_text
-	
+	Input.mouse_mode = Input.MOUSE_MODE_VISIBLE
 	show()
 
 func _on_try_again_pressed():


### PR DESCRIPTION
The error was that by deleting the player code, you accidentally deleted the line that allowed the Input mode to become visible again (which was in FirstPersonController.gd line 39). By adding it to the the FinalMenu.gd script this enables you to regain control of the mouse when the initialize function is called.